### PR TITLE
Fix alpha autobump

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
 
   steps:
     - name: Use Node.js from package.json
-      uses: actions/setup-node@v4.0.3
+      uses: actions/setup-node@v4
       with:
         node-version-file: 'package.json'
         cache: "npm"

--- a/bump-package-version.sh
+++ b/bump-package-version.sh
@@ -62,7 +62,7 @@ fi
 
 # Set alpha tag to the correspondent version
 echo "Setting alpha version to $alphaVersionCounter"
-sed -i 's/\("version": "[0-9]\+.[0-9]\+.[0-9]\+\)\(-alpha.\)\([0-9]\)/\1\'-alpha.$alphaVersionCounter'/' package.json
+sed -i "s/\(\"version\": \"[0-9]\+\.[0-9]\+\.[0-9]\+\)\(-alpha\.\)\([0-9]\+\)/\1-alpha.$alphaVersionCounter/" package.json
 
 # If there was a version bump, commit changes with [skip ci]
 if [[ "$initialPackageJSON" != "$upToDatePackageJSON" ]];


### PR DESCRIPTION
**Error:** 
"package.json": extra characters at the end of p command

**Solution:**
The error “extra characters at the end of p command” in your sed command arises from incorrect quoting or escaping.


**Fix Breakdown**
	1. Switch to Double Quotes ("):
	Double quotes allow shell variable expansion ($alphaVersionCounter) within the string.
	2. Escape Special Characters:
	The double quotes (") need escaping around version in the pattern: \".
	The backslashes (\) ensure + and . are treated as regex operators.
	3. Avoid Misplaced Escapes:
	Removed unnecessary \' in the replacement part, which was misinterpreted.